### PR TITLE
Scale option

### DIFF
--- a/data/com.github.mohelm97.screenrecorder.gschema.xml
+++ b/data/com.github.mohelm97.screenrecorder.gschema.xml
@@ -32,7 +32,7 @@
             <default>30</default>
         </key>
         <key name="scale" type="i">
-            <range min="1" max="100"/>
+            <range min="1" max="200"/>
             <default>100</default>
         </key>
         <key name="folder-dir" type="s">

--- a/data/com.github.mohelm97.screenrecorder.gschema.xml
+++ b/data/com.github.mohelm97.screenrecorder.gschema.xml
@@ -31,6 +31,10 @@
             <range min="1" max="120"/>
             <default>30</default>
         </key>
+        <key name="scale" type="i">
+            <range min="1" max="100"/>
+            <default>100</default>
+        </key>
         <key name="folder-dir" type="s">
             <default>""</default>
         </key>

--- a/meson.build
+++ b/meson.build
@@ -16,6 +16,8 @@ icon_res = gnome.compile_resources(
 # Adding deps
 message ('Listing dependencies')
 
+cc = meson.get_compiler('c')
+
 dependencies = [
     dependency('gee-0.8'),
     dependency('granite'),
@@ -24,7 +26,8 @@ dependencies = [
     dependency('gdk-x11-3.0'),
     dependency('gstreamer-1.0'),
     dependency('clutter-gst-3.0'),
-    dependency('clutter-gtk-1.0')
+    dependency('clutter-gtk-1.0'),
+    cc.find_library('m', required : false)
 ]
 
 # Create a new executable, list the files we want to compile, list the dependencies we need, and install

--- a/meson.build
+++ b/meson.build
@@ -16,8 +16,6 @@ icon_res = gnome.compile_resources(
 # Adding deps
 message ('Listing dependencies')
 
-cc = meson.get_compiler('c')
-
 dependencies = [
     dependency('gee-0.8'),
     dependency('granite'),
@@ -26,8 +24,7 @@ dependencies = [
     dependency('gdk-x11-3.0'),
     dependency('gstreamer-1.0'),
     dependency('clutter-gst-3.0'),
-    dependency('clutter-gtk-1.0'),
-    cc.find_library('m', required : false)
+    dependency('clutter-gtk-1.0')
 ]
 
 # Create a new executable, list the files we want to compile, list the dependencies we need, and install

--- a/meson.build
+++ b/meson.build
@@ -41,6 +41,7 @@ executable(
     'src/Widgets/SelectionArea.vala',
     'src/Widgets/VideoPlayer.vala',
     'src/Widgets/FormatComboBox.vala',
+    'src/Widgets/ScaleComboBox.vala',
     'src/Utils/KeybindingManager.vala',
     dependencies: dependencies,
     install: true

--- a/src/FFmpegWrapper.vala
+++ b/src/FFmpegWrapper.vala
@@ -31,6 +31,7 @@ namespace ScreenRecorder {
             int start_y,
             int width,
             int height,
+            float scale,
             bool show_mouse,
             bool show_borders,
             bool record_cmp,
@@ -77,6 +78,15 @@ namespace ScreenRecorder {
                 }
                 spawn_args += "-preset";
                 spawn_args += "ultrafast";
+
+                // scale video
+                spawn_args += "-filter:v";
+                var filter = "scale=iw*%.2f:-1".printf (scale).replace (",", ".");
+                if (!is_gif) {
+                  filter += ", crop=iw-mod(iw\\,2):ih-mod(ih\\,2)";
+                }
+                spawn_args += filter;
+
                 spawn_args += filepath;
 
                 debug ("ffmpeg command: %s",string.joinv(" ", spawn_args));

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -19,7 +19,7 @@
 * Authored by: Mohammed ALMadhoun <mohelm97@gmail.com>
 */
 
-namespace ScreenRecorder { 
+namespace ScreenRecorder {
     public class MainWindow : Gtk.ApplicationWindow  {
         private enum CaptureType {
             SCREEN,
@@ -111,9 +111,7 @@ namespace ScreenRecorder {
             var scale_label = new Gtk.Label (_("Scale:"));
             scale_label.halign = Gtk.Align.END;
 
-            var scale_spin = new Gtk.SpinButton.with_range (1, 100, 1);
-
-            var scale_units = new Gtk.Label (_("%"));
+            var scale_combobox = new ScaleComboBox ();
 
             var format_label = new Gtk.Label (_("Format:"));
             format_label.halign = Gtk.Align.END;
@@ -149,22 +147,21 @@ namespace ScreenRecorder {
             grid.margin_top = 0;
             grid.row_spacing = 6;
             grid.column_spacing = 12;
-            grid.attach (radio_grid        , 0, 0, 3, 1);
+            grid.attach (radio_grid        , 0, 0, 2, 1);
             grid.attach (record_cmp_label  , 0, 1, 1, 1);
-            grid.attach (record_cmp_switch , 1, 1, 2, 1);
+            grid.attach (record_cmp_switch , 1, 1, 1, 1);
             grid.attach (record_mic_label  , 0, 2, 1, 1);
             grid.attach (record_mic_switch , 1, 2, 1, 1);
             grid.attach (pointer_label     , 0, 3, 1, 1);
-            grid.attach (pointer_switch    , 1, 3, 2, 1);
+            grid.attach (pointer_switch    , 1, 3, 1, 1);
             grid.attach (borders_label     , 0, 4, 1, 1);
-            grid.attach (borders_switch    , 1, 4, 2, 1);
+            grid.attach (borders_switch    , 1, 4, 1, 1);
             grid.attach (delay_label       , 0, 5, 1, 1);
             grid.attach (delay_spin        , 1, 5, 1, 1);
             grid.attach (framerate_label   , 0, 6, 1, 1);
             grid.attach (framerate_spin    , 1, 6, 1, 1);
             grid.attach (scale_label       , 0, 7, 1, 1);
-            grid.attach (scale_spin        , 1, 7, 1, 1);
-            grid.attach (scale_units       , 2, 7, 1, 1);
+            grid.attach (scale_combobox    , 1, 7, 1, 1);
             grid.attach (format_label      , 0, 8, 1, 1);
             grid.attach (format_cmb        , 1, 8, 1, 1);
 
@@ -177,7 +174,7 @@ namespace ScreenRecorder {
             titlebar.show_close_button = true;
             titlebar.has_subtitle = false;
             titlebar.pack_end (mode_switch);
-            
+
             var titlebar_style_context = titlebar.get_style_context ();
             titlebar_style_context.add_class (Gtk.STYLE_CLASS_FLAT);
             //titlebar_style_context.add_class ("default-decoration");
@@ -200,11 +197,11 @@ namespace ScreenRecorder {
             settings.bind ("show-borders", borders_switch, "active", GLib.SettingsBindFlags.DEFAULT);
             settings.bind ("delay", delay_spin, "value", GLib.SettingsBindFlags.DEFAULT);
             settings.bind ("framerate", framerate_spin, "value", GLib.SettingsBindFlags.DEFAULT);
-            settings.bind ("scale", scale_spin, "value", GLib.SettingsBindFlags.DEFAULT);
+            settings.bind ("scale", scale_combobox, "scale", GLib.SettingsBindFlags.DEFAULT);
             settings.bind ("format", format_cmb, "text_value", GLib.SettingsBindFlags.DEFAULT);
             delay = delay_spin.get_value_as_int () * 1000;
             framerate = framerate_spin.get_value_as_int ();
-            scale_percentage = scale_spin.get_value_as_int ();
+            scale_percentage = scale_combobox.scale;
 
             format_cmb.changed.connect (() => {
                 if (format_cmb.get_active_text () == "gif") {
@@ -233,8 +230,8 @@ namespace ScreenRecorder {
                 framerate = framerate_spin.get_value_as_int ();
             });
 
-            scale_spin.value_changed.connect (() => {
-                scale_percentage = scale_spin.get_value_as_int ();
+            scale_combobox.changed.connect (() => {
+                scale_percentage = scale_combobox.scale;
             });
 
             all.toggled.connect (() => {
@@ -339,7 +336,7 @@ namespace ScreenRecorder {
             actions.add (stop_btn);
             stop_btn.show ();
         }
-        
+
         void stop_recording () {
             ffmpegwrapper.stop();
             present ();

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -113,6 +113,8 @@ namespace ScreenRecorder {
 
             var scale_spin = new Gtk.SpinButton.with_range (1, 100, 1);
 
+            var scale_units = new Gtk.Label (_("%"));
+
             var format_label = new Gtk.Label (_("Format:"));
             format_label.halign = Gtk.Align.END;
 
@@ -147,21 +149,22 @@ namespace ScreenRecorder {
             grid.margin_top = 0;
             grid.row_spacing = 6;
             grid.column_spacing = 12;
-            grid.attach (radio_grid        , 0, 0, 2, 1);
+            grid.attach (radio_grid        , 0, 0, 3, 1);
             grid.attach (record_cmp_label  , 0, 1, 1, 1);
-            grid.attach (record_cmp_switch , 1, 1, 1, 1);
+            grid.attach (record_cmp_switch , 1, 1, 2, 1);
             grid.attach (record_mic_label  , 0, 2, 1, 1);
             grid.attach (record_mic_switch , 1, 2, 1, 1);
             grid.attach (pointer_label     , 0, 3, 1, 1);
-            grid.attach (pointer_switch    , 1, 3, 1, 1);
+            grid.attach (pointer_switch    , 1, 3, 2, 1);
             grid.attach (borders_label     , 0, 4, 1, 1);
-            grid.attach (borders_switch    , 1, 4, 1, 1);
+            grid.attach (borders_switch    , 1, 4, 2, 1);
             grid.attach (delay_label       , 0, 5, 1, 1);
             grid.attach (delay_spin        , 1, 5, 1, 1);
             grid.attach (framerate_label   , 0, 6, 1, 1);
             grid.attach (framerate_spin    , 1, 6, 1, 1);
             grid.attach (scale_label       , 0, 7, 1, 1);
             grid.attach (scale_spin        , 1, 7, 1, 1);
+            grid.attach (scale_units       , 2, 7, 1, 1);
             grid.attach (format_label      , 0, 8, 1, 1);
             grid.attach (format_cmb        , 1, 8, 1, 1);
 

--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -40,6 +40,7 @@ namespace ScreenRecorder {
         private bool recording = false;
         private int delay;
         private int framerate;
+        private int scale_percentage;
         private string tmpfilepath;
         private int last_recording_width = 0;
         private int last_recording_height = 0;
@@ -107,6 +108,11 @@ namespace ScreenRecorder {
 
             var framerate_spin = new Gtk.SpinButton.with_range (1, 120, 1);
 
+            var scale_label = new Gtk.Label (_("Scale:"));
+            scale_label.halign = Gtk.Align.END;
+
+            var scale_spin = new Gtk.SpinButton.with_range (1, 100, 1);
+
             var format_label = new Gtk.Label (_("Format:"));
             format_label.halign = Gtk.Align.END;
 
@@ -154,8 +160,10 @@ namespace ScreenRecorder {
             grid.attach (delay_spin        , 1, 5, 1, 1);
             grid.attach (framerate_label   , 0, 6, 1, 1);
             grid.attach (framerate_spin    , 1, 6, 1, 1);
-            grid.attach (format_label      , 0, 7, 1, 1);
-            grid.attach (format_cmb        , 1, 7, 1, 1);
+            grid.attach (scale_label       , 0, 7, 1, 1);
+            grid.attach (scale_spin        , 1, 7, 1, 1);
+            grid.attach (format_label      , 0, 8, 1, 1);
+            grid.attach (format_cmb        , 1, 8, 1, 1);
 
             var mode_switch = new Granite.ModeSwitch.from_icon_name ("display-brightness-symbolic", "weather-clear-night-symbolic");
             mode_switch.primary_icon_tooltip_text = ("Light background");
@@ -189,9 +197,11 @@ namespace ScreenRecorder {
             settings.bind ("show-borders", borders_switch, "active", GLib.SettingsBindFlags.DEFAULT);
             settings.bind ("delay", delay_spin, "value", GLib.SettingsBindFlags.DEFAULT);
             settings.bind ("framerate", framerate_spin, "value", GLib.SettingsBindFlags.DEFAULT);
+            settings.bind ("scale", scale_spin, "value", GLib.SettingsBindFlags.DEFAULT);
             settings.bind ("format", format_cmb, "text_value", GLib.SettingsBindFlags.DEFAULT);
             delay = delay_spin.get_value_as_int () * 1000;
             framerate = framerate_spin.get_value_as_int ();
+            scale_percentage = scale_spin.get_value_as_int ();
 
             format_cmb.changed.connect (() => {
                 if (format_cmb.get_active_text () == "gif") {
@@ -218,6 +228,10 @@ namespace ScreenRecorder {
 
             framerate_spin.value_changed.connect (() => {
                 framerate = framerate_spin.get_value_as_int ();
+            });
+
+            scale_spin.value_changed.connect (() => {
+                scale_percentage = scale_spin.get_value_as_int ();
             });
 
             all.toggled.connect (() => {
@@ -310,6 +324,7 @@ namespace ScreenRecorder {
                 selection_rect.y,
                 selection_rect.width,
                 selection_rect.height,
+                (float) scale_percentage / 100,
                 pointer_switch.get_state (),
                 borders_switch.get_state (),
                 record_cmp_switch.get_state (),

--- a/src/SaveDialog.vala
+++ b/src/SaveDialog.vala
@@ -82,7 +82,7 @@ namespace ScreenRecorder {
             var file_name = _("Screen record from %s").printf (date_time);
 
             var scale = (float) settings.get_int ("scale") / 100;
-            var actual_scale = (int) Math.floor (this.scale_factor * scale);
+            var actual_scale = (int) (this.scale_factor * scale);
             if (actual_scale > 1) {
                 file_name += "@%ix".printf (actual_scale);
             }

--- a/src/SaveDialog.vala
+++ b/src/SaveDialog.vala
@@ -81,8 +81,10 @@ namespace ScreenRecorder {
             /// TRANSLATORS: %s represents a timestamp here
             var file_name = _("Screen record from %s").printf (date_time);
 
-            if (this.scale_factor > 1) {
-                file_name += "@%ix".printf (this.scale_factor);
+            var scale = (float) settings.get_int ("scale") / 100;
+            var actual_scale = (int) Math.floor (this.scale_factor * scale);
+            if (actual_scale > 1) {
+                file_name += "@%ix".printf (actual_scale);
             }
 
             name_entry = new Gtk.Entry ();

--- a/src/SaveDialog.vala
+++ b/src/SaveDialog.vala
@@ -76,16 +76,9 @@ namespace ScreenRecorder {
             var name_label = new Gtk.Label (_("Name:"));
             name_label.halign = Gtk.Align.END;
 
-            var date_time = new GLib.DateTime.now_local ().format ("%Y-%m-%d %H.%M.%S");
-
-            /// TRANSLATORS: %s represents a timestamp here
-            var file_name = _("Screen record from %s").printf (date_time);
-
-            var scale = (float) settings.get_int ("scale") / 100;
-            var actual_scale = (int) (this.scale_factor * scale);
-            if (actual_scale > 1) {
-                file_name += "@%ix".printf (actual_scale);
-            }
+            var recording_scale = (double) settings.get_int ("scale") / 100;
+            var screen_scale = this.scale_factor;
+            var file_name = get_file_name (recording_scale, screen_scale);
 
             name_entry = new Gtk.Entry ();
             name_entry.hexpand = true;
@@ -186,6 +179,31 @@ namespace ScreenRecorder {
 
         private void remove_temp () {
             GLib.FileUtils.remove (filepath);
+        }
+
+        /**
+         * Generate file name
+         * When appropriate include a scale hint that websites can use to 
+         * scale down recordings on higher dpi screens. 
+         */
+        private string get_file_name (double recording_scale, double screen_scale) {
+            var date_time = new GLib.DateTime.now_local ().format ("%Y-%m-%d %H.%M.%S");
+
+            /// TRANSLATORS: %s represents a timestamp here
+            var file_name = _("Screen record from %s").printf (date_time);
+            var file_scale = get_file_scale (recording_scale, screen_scale);
+            if (file_scale > 1) {
+                file_name += "@%ix".printf (file_scale);
+            }
+            return file_name;
+        }
+
+        private int get_file_scale (double recording_scale, double screen_scale) {
+            var file_scale = screen_scale * recording_scale;
+            // never make it seem like images are taken on higher dpi screen
+            file_scale = (file_scale > screen_scale)? screen_scale : file_scale;
+            file_scale = (file_scale < 1)? 1 : file_scale;
+            return (int) file_scale;
         }
     }
 }

--- a/src/Widgets/ScaleComboBox.vala
+++ b/src/Widgets/ScaleComboBox.vala
@@ -1,0 +1,43 @@
+/*
+* Copyright (c) 2018 mohelm97 (https://github.com/mohelm97/screenrecorder)
+*
+* This program is free software; you can redistribute it and/or
+* modify it under the terms of the GNU General Public
+* License as published by the Free Software Foundation; either
+* version 2 of the License, or (at your option) any later version.
+*
+* This program is distributed in the hope that it will be useful,
+* but WITHOUT ANY WARRANTY; without even the implied warranty of
+* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+* General Public License for more details.
+*
+* You should have received a copy of the GNU General Public
+* License along with this program; if not, write to the
+* Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+* Boston, MA 02110-1301 USA
+*
+* Authored by: Peter Uithoven <peter@peteruithoven.nl>
+*/
+
+namespace ScreenRecorder {
+    public class ScaleComboBox : Gtk.ComboBoxText {
+        public int scale {
+            get {
+                return int.parse (active_id);
+            }
+            set {
+                active_id = value.to_string ();
+            }
+        }
+        public ScaleComboBox () {
+            int [] scales = { 25, 50, 75, 100, 200 };
+            foreach (int scale in scales) {
+                var scale_id = scale.to_string();
+                append (scale_id, scale_id + "%");
+            }
+            changed.connect(() => {
+                scale = scale;
+            });
+        }
+    }
+}


### PR DESCRIPTION
Implements: https://github.com/Mohelm97/screenrecorder/issues/9
Allows users to scale the video to reduce file size. 
Uses [ffmpeg's scale filter](https://ffmpeg.org/ffmpeg-filters.html#scale-1). 

ToDo:
- [x] Use ffmpeg scale argument
- [x] Add option to UI
- [x] Add "%" unit to UI
- [x] Correct "@2x" in file name
- [x] Decide on UI