### PR TITLE
Fix alignment of mode_switch in titlebar

### DIFF
--- a/src/MainWindow.vala
+++ b/src/MainWindow.vala
@@ -168,6 +168,7 @@ namespace ScreenRecorder {
             var mode_switch = new Granite.ModeSwitch.from_icon_name ("display-brightness-symbolic", "weather-clear-night-symbolic");
             mode_switch.primary_icon_tooltip_text = ("Light background");
             mode_switch.secondary_icon_tooltip_text = ("Dark background");
+            mode_switch.valign = Gtk.Align.CENTER;
 
             var titlebar = new Gtk.HeaderBar ();
             titlebar.title = _("Screen Recorder");


### PR DESCRIPTION
First of all, thank you for making a nice app! I'd been using Peek to take a GIF image to clarify the content of pull requests and issues, but yesterday I tried using your app and found it is more useful. What I personally liked is the GIF preview in the saving dialog. This allows me to check the GIF and discard it if there is some mistake in it.

### Changes Summary

What this PR fixes is really tiny thing :sweat_smile: I just vertically centered mode_switch button in the center of titlebar.

### BEFORE

![screenshot from 2019-02-19 17-34-27](https://user-images.githubusercontent.com/26003928/53002118-4844e680-346f-11e9-91c5-8b014899f0be.png)

### AFTER

![screenshot from 2019-02-19 17-34-51](https://user-images.githubusercontent.com/26003928/53002121-48dd7d00-346f-11e9-918c-acb0c2549e10.png)

### BEFORE with layout borders

![screenshot from 2019-02-19 17-34-39](https://user-images.githubusercontent.com/26003928/53002120-48dd7d00-346f-11e9-9e7f-37b7dbe5db76.png)

### AFTER with layout borders

![screenshot from 2019-02-19 17-35-04](https://user-images.githubusercontent.com/26003928/53002122-48dd7d00-346f-11e9-914b-488b7d1c9c0e.png)
