### PR TITLE
Fix deprecations

### DIFF
--- a/src/Application.vala
+++ b/src/Application.vala
@@ -53,7 +53,7 @@ namespace ScreenRecorder {
                     File records_folder = File.new_for_path (settings.get_string ("folder-dir"));
                     AppInfo.launch_default_for_uri (records_folder.get_uri (), null);
                     debug("launch_default_for_uri %s".printf (parameter.get_string ()));
-                } catch (SpawnError e) {
+                } catch (Error e) {
                     GLib.warning (e.message);
                 }
             });

--- a/src/Widgets/SelectionArea.vala
+++ b/src/Widgets/SelectionArea.vala
@@ -38,8 +38,10 @@ namespace Screenshot.Widgets {
             set_skip_pager_hint (true);
             set_keep_above (true);
 
-            var screen = get_screen ();
-            set_default_size (screen.get_width (), screen.get_height ());
+            var display = Gdk.Display.get_default ();
+            Gdk.Monitor monitor = display.get_primary_monitor ();
+            Gdk.Rectangle geom = monitor.get_geometry ();
+            set_default_size (geom.width, geom.height);
         }
 
         public override bool button_press_event (Gdk.EventButton e) {

--- a/src/Widgets/SelectionArea.vala
+++ b/src/Widgets/SelectionArea.vala
@@ -101,33 +101,19 @@ namespace Screenshot.Widgets {
 
         public override void show_all () {
             base.show_all ();
-            var manager = Gdk.Display.get_default ().get_device_manager ();
-            var pointer = manager.get_client_pointer ();
-            var keyboard = pointer.get_associated_device ();
+
+            var manager = Gdk.Display.get_default ().get_default_seat ();
             var window = get_window ();
 
-            var status = pointer.grab (window,
-                        Gdk.GrabOwnership.NONE,
+            var status = manager.grab (window,
+                        Gdk.SeatCapabilities.ALL,
                         false,
-                        Gdk.EventMask.BUTTON_PRESS_MASK | Gdk.EventMask.BUTTON_RELEASE_MASK | Gdk.EventMask.POINTER_MOTION_MASK,
                         new Gdk.Cursor.for_display (window.get_display (), Gdk.CursorType.CROSSHAIR),
-                        Gtk.get_current_event_time ());
+                        new Gdk.Event (Gdk.EventType.BUTTON_PRESS | Gdk.EventType.BUTTON_RELEASE | Gdk.EventType.MOTION_NOTIFY),
+                        null);
 
             if (status != Gdk.GrabStatus.SUCCESS) {
-                pointer.ungrab (Gtk.get_current_event_time ());
-            }
-
-            if (keyboard != null) {
-                status = keyboard.grab (window,
-                        Gdk.GrabOwnership.NONE,
-                        false,
-                        Gdk.EventMask.KEY_PRESS_MASK,
-                        null,
-                        Gtk.get_current_event_time ());
-
-                if (status != Gdk.GrabStatus.SUCCESS) {
-                    keyboard.ungrab (Gtk.get_current_event_time ());
-                }                
+                manager.ungrab ();
             }
         }
 


### PR DESCRIPTION
Fixes these warnings on compile:

```
../src/Widgets/SelectionArea.vala:42.31-42.46: warning: Gdk.Screen.get_width has been deprecated since 3.22
../src/Widgets/SelectionArea.vala:42.52-42.68: warning: Gdk.Screen.get_height has been deprecated since 3.22
../src/Widgets/SelectionArea.vala:102.27-102.71: warning: Gdk.Display.get_device_manager has been deprecated since 3.20.
../src/Widgets/SelectionArea.vala:103.27-103.52: warning: Gdk.DeviceManager.get_client_pointer has been deprecated since 3.20
../src/Widgets/SelectionArea.vala:107.26-107.37: warning: Gdk.Device.grab has been deprecated since 3.20.
../src/Widgets/SelectionArea.vala:115.17-115.30: warning: Gdk.Device.ungrab has been deprecated since 3.20.
../src/Widgets/SelectionArea.vala:119.26-119.38: warning: Gdk.Device.grab has been deprecated since 3.20.
../src/Widgets/SelectionArea.vala:127.21-127.35: warning: Gdk.Device.ungrab has been deprecated since 3.20.
../src/Application.vala:54.21-54.84: warning: unhandled error `GLib.Error'
                    AppInfo.launch_default_for_uri (records_folder.get_uri (), null);
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
Compilation succeeded - 9 warning(s)
```
